### PR TITLE
 Mark navigation as reactive

### DIFF
--- a/src/lib/components/Navigation.svelte
+++ b/src/lib/components/Navigation.svelte
@@ -2,7 +2,7 @@
 	import { session } from '$app/stores';
 	import { goto } from '$app/navigation';
 
-	const navigation = [
+	$: navigation = [
 		{
 			href: '/',
 			name: 'Home',


### PR DESCRIPTION
With this change the padlog symbol in the navigation bar updates, when the user signs in or out.